### PR TITLE
✨ Add usage of a specific endpoint port

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Serve Flags:
       --elasticsearch-endpoint-suffix=".service.{dc}.foo.bar"
                                 Suffix to add after the consul service name to
                                 create a valid domain name
+      --elasticsearch-endpoint-port=-1
+                                Elasticsearch port used for cluster authentication
       --elasticsearch-user=STRING
                                 Elasticsearch username
       --elasticsearch-password=STRING

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Serve Flags:
                                 Suffix to add after the consul service name to
                                 create a valid domain name
       --elasticsearch-endpoint-port=0
-                                Elasticsearch port used for cluster authentication
+                                Elasticsearch port used for cluster level calls
       --elasticsearch-user=STRING
                                 Elasticsearch username
       --elasticsearch-password=STRING

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Serve Flags:
       --elasticsearch-endpoint-suffix=".service.{dc}.foo.bar"
                                 Suffix to add after the consul service name to
                                 create a valid domain name
-      --elasticsearch-endpoint-port=-1
+      --elasticsearch-endpoint-port=0
                                 Elasticsearch port used for cluster authentication
       --elasticsearch-user=STRING
                                 Elasticsearch username

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -19,6 +19,7 @@ type ServeCmd struct {
 	CleaningPeriod                           time.Duration `default:"600s" help:"prometheus metrics cleaning interval (for vanished nodes)"`
 	ElasticsearchConsulTag                   string        `default:"maintenance-elasticsearch" help:"elasticsearch consul tag"`
 	ElasticsearchEndpointSuffix              string        `default:".service.{dc}.foo.bar" help:"Suffix to add after the consul service name to create a valid domain name"`
+	ElasticsearchEndpointPort                int           `default:"-1" help:"Elasticsearch port used for cluster authentication"`
 	ElasticsearchUser                        string        `help:"Elasticsearch username"`
 	ElasticsearchPassword                    string        `help:"Elasticsearch password"`
 	ElasticsearchDurabilityIndex             string        `default:".espoke.durability" help:"Elasticsearch durability index"`
@@ -73,6 +74,7 @@ func (r *ServeCmd) Run() error {
 	config := &common.Config{
 		ElasticsearchConsulTag:                   r.ElasticsearchConsulTag,
 		ElasticsearchEndpointSuffix:              r.ElasticsearchEndpointSuffix,
+		ElasticsearchEndpointPort:                r.ElasticsearchEndpointPort,
 		ElasticsearchUser:                        r.ElasticsearchUser,
 		ElasticsearchPassword:                    r.ElasticsearchPassword,
 		ElasticsearchDurabilityIndex:             r.ElasticsearchDurabilityIndex,

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -19,7 +19,7 @@ type ServeCmd struct {
 	CleaningPeriod                           time.Duration `default:"600s" help:"prometheus metrics cleaning interval (for vanished nodes)"`
 	ElasticsearchConsulTag                   string        `default:"maintenance-elasticsearch" help:"elasticsearch consul tag"`
 	ElasticsearchEndpointSuffix              string        `default:".service.{dc}.foo.bar" help:"Suffix to add after the consul service name to create a valid domain name"`
-	ElasticsearchEndpointPort                int           `default:"-1" help:"Elasticsearch port used for cluster authentication"`
+	ElasticsearchEndpointPort                int           `default:"0" help:"Elasticsearch port used for cluster authentication"`
 	ElasticsearchUser                        string        `help:"Elasticsearch username"`
 	ElasticsearchPassword                    string        `help:"Elasticsearch password"`
 	ElasticsearchDurabilityIndex             string        `default:".espoke.durability" help:"Elasticsearch durability index"`

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -19,7 +19,7 @@ type ServeCmd struct {
 	CleaningPeriod                           time.Duration `default:"600s" help:"prometheus metrics cleaning interval (for vanished nodes)"`
 	ElasticsearchConsulTag                   string        `default:"maintenance-elasticsearch" help:"elasticsearch consul tag"`
 	ElasticsearchEndpointSuffix              string        `default:".service.{dc}.foo.bar" help:"Suffix to add after the consul service name to create a valid domain name"`
-	ElasticsearchEndpointPort                int           `default:"0" help:"Elasticsearch port used for cluster authentication"`
+	ElasticsearchEndpointPort                int           `default:"0" help:"Elasticsearch port used for cluster level calls"`
 	ElasticsearchUser                        string        `help:"Elasticsearch username"`
 	ElasticsearchPassword                    string        `help:"Elasticsearch password"`
 	ElasticsearchDurabilityIndex             string        `default:".espoke.durability" help:"Elasticsearch durability index"`

--- a/common/discovery.go
+++ b/common/discovery.go
@@ -107,19 +107,27 @@ func GetServices(consul *api.Client, consulTag string) (map[string]Cluster, erro
 	return services, nil
 }
 
-func GetEndpointFromConsul(consul *api.Client, name, endpointSuffix string) (string, error) {
+func GetEndpointFromConsul(consul *api.Client, name, endpointSuffix string, endpointPort int) (string, error) {
 	endpoint := ""
 
 	health := consul.Health()
 	serviceEntries, _, _ := health.Service(name, "", false, nil)
 
-	port, err := getServicePort(serviceEntries)
-	if err != nil {
-		return endpoint, err
+	if endpointPort == -1 {
+		var err error
+		endpointPort, err = getServicePort(serviceEntries)
+		if err != nil {
+			return "", err
+		}
 	}
+
 	dc, err := getDatacenter(serviceEntries)
+	if err != nil {
+		return "", err
+	}
+
 	endpointSuffixWithDC := strings.ReplaceAll(endpointSuffix, "{dc}", dc)
-	endpoint = fmt.Sprintf("%s%s:%d", name, endpointSuffixWithDC, port)
+	endpoint = fmt.Sprintf("%s%s:%d", name, endpointSuffixWithDC, endpointPort)
 
 	return endpoint, nil
 }

--- a/common/discovery.go
+++ b/common/discovery.go
@@ -113,7 +113,7 @@ func GetEndpointFromConsul(consul *api.Client, name, endpointSuffix string, endp
 	health := consul.Health()
 	serviceEntries, _, _ := health.Service(name, "", false, nil)
 
-	if endpointPort == -1 {
+	if endpointPort == 0 {
 		var err error
 		endpointPort, err = getServicePort(serviceEntries)
 		if err != nil {

--- a/common/schema.go
+++ b/common/schema.go
@@ -20,6 +20,7 @@ type Cluster struct {
 type Config struct {
 	ElasticsearchConsulTag                   string
 	ElasticsearchEndpointSuffix              string
+	ElasticsearchEndpointPort                int
 	ElasticsearchUser                        string
 	ElasticsearchPassword                    string
 	ElasticsearchDurabilityIndex             string

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -82,7 +82,7 @@ func (w *Watcher) createNewEsProbes(servicesToAdd map[string]common.Cluster) {
 	for cluster, clusterConfig := range servicesToAdd {
 		log.Printf("Creating new es probe for: %s", cluster)
 
-		endpoint, err := common.GetEndpointFromConsul(w.consulClient, clusterConfig.Name, w.config.ElasticsearchEndpointSuffix)
+		endpoint, err := common.GetEndpointFromConsul(w.consulClient, clusterConfig.Name, w.config.ElasticsearchEndpointSuffix, w.config.ElasticsearchEndpointPort)
 		if err != nil {
 			log.Errorf("Could not generate endpoint from consul: %s", err.Error())
 			common.ErrorsCount.Inc()


### PR DESCRIPTION
When pulling cluster from Consul, the port exposed is not
necessarily the one that must be used in order to authenticate
on the cluster. This feature allows to set a different endpoint
pot to authenticate on the ElasticSearch cluster.

By default, the endpoint port is the one exposed in Consul.