### PR TITLE
Add OpenSearch restore monitoring & some refactoring

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,13 +4,15 @@
 package cmd
 
 import (
-	"github.com/criteo-forks/espoke/common"
-	"github.com/criteo-forks/espoke/watcher"
 	"os"
 	"time"
 
+	"github.com/criteo-forks/espoke/common"
+	"github.com/criteo-forks/espoke/watcher"
+
 	log "github.com/sirupsen/logrus"
 )
+
 type ServeCmd struct {
 	ConsulApi                                string        `default:"127.0.0.1:8500" help:"127.0.0.1:8500" help:"consul target api host:port" short:"a"`
 	ConsulPeriod                             time.Duration `default:"120s" help:"nodes discovery update interval"`
@@ -27,11 +29,12 @@ type ServeCmd struct {
 	ElasticsearchNumberOfDurabilityDocuments int           `default:"100000" help:"Number of documents to stored in the durability index"`
 	ElasticsearchRestore                     bool          `default:"false" help:"Perform Elasticsearch restore test"`
 	ElasticsearchRestoreSnapshotRepository   string        `default:"ceph_s3" help:"Name of the Elasticsearch snapshot repository"`
-	ElasticsearchRestoreSnapshotPolicy       string        `default:"probe-snapshot" help:"Name of the Elasticsearch snapshot policy"`
+	ElasticsearchRestoreSnapshotPolicy       string        `default:"probe-snapshot-sm" help:"Name of the Elasticsearch snapshot policy"`
 	LatencyProbeRatePerMin                   int           `default:"120" help:"Rate of latency probing per minute (how many checks are done in a minute)"`
 	KibanaConsulTag                          string        `default:"maintenance-kibana" help:"kibana consul tag"`
 	MetricsPort                              int           `default:"2112" help:"port where prometheus will expose metrics to" short:"p"`
 	LogLevel                                 string        `default:"info" help:"log level" yaml:"log_level" short:"l"`
+	Opensearch                               bool          `default:"true" help:"Probe monitors opensearch clusters"`
 }
 
 func (r *ServeCmd) Run() error {
@@ -71,6 +74,10 @@ func (r *ServeCmd) Run() error {
 		log.Info("Restore interval: ", r.RestorePeriod.String())
 	}
 
+	if r.Opensearch {
+		log.Info("Opensearch: yes")
+	}
+
 	config := &common.Config{
 		ElasticsearchConsulTag:                   r.ElasticsearchConsulTag,
 		ElasticsearchEndpointSuffix:              r.ElasticsearchEndpointSuffix,
@@ -90,6 +97,7 @@ func (r *ServeCmd) Run() error {
 		ProbePeriod:                              r.ProbePeriod,
 		RestorePeriod:                            r.RestorePeriod,
 		CleaningPeriod:                           r.CleaningPeriod,
+		Opensearch:                               r.Opensearch,
 	}
 
 	w, err := watcher.NewWatcher(config)

--- a/common/schema.go
+++ b/common/schema.go
@@ -36,4 +36,5 @@ type Config struct {
 	ProbePeriod                              time.Duration
 	RestorePeriod                            time.Duration
 	CleaningPeriod                           time.Duration
+	Opensearch                               bool
 }

--- a/probe/elasticsearch.go
+++ b/probe/elasticsearch.go
@@ -80,7 +80,7 @@ type EsProbe struct {
 	controlChan chan bool
 }
 
-func NewEsProbe(clusterName string, endpoint string, clusterConfig common.Cluster, config *common.Config, consulClient *api.Client, controlChan chan bool) (EsProbe, error) {
+func NewEsProbe(clusterName string, clusterConfig common.Cluster, config *common.Config, consulClient *api.Client, controlChan chan bool) (EsProbe, error) {
 	var allEverKnownEsNodes []string
 	esNodesList, err := common.DiscoverNodesForService(consulClient, clusterConfig.Name)
 	if err != nil {
@@ -88,7 +88,7 @@ func NewEsProbe(clusterName string, endpoint string, clusterConfig common.Cluste
 	}
 	allEverKnownEsNodes = common.UpdateEverKnownNodes(allEverKnownEsNodes, esNodesList)
 
-	client, err := initEsClient(clusterConfig.Scheme, endpoint, config.ElasticsearchUser, config.ElasticsearchPassword)
+	client, err := initEsClient(clusterConfig.Scheme, clusterConfig.Endpoint, config.ElasticsearchUser, config.ElasticsearchPassword)
 	if err != nil {
 		return EsProbe{}, errors.Wrapf(err, "Failed to init elasticsearch client for cluster %s", clusterName)
 	}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -90,8 +90,10 @@ func (w *Watcher) createNewEsProbes(servicesToAdd map[string]common.Cluster) {
 			continue
 		}
 
+		clusterConfig.Endpoint = endpoint
+
 		probeChan = make(chan bool)
-		esProbe, err := probe.NewEsProbe(cluster, endpoint, clusterConfig, w.config, w.consulClient, probeChan)
+		esProbe, err := probe.NewEsProbe(cluster, clusterConfig, w.config, w.consulClient, probeChan)
 
 		if err != nil {
 			log.Errorf("Error while creating probe: %s", err.Error())

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -1,11 +1,12 @@
 package watcher
 
 import (
+	"time"
+
 	"github.com/criteo-forks/espoke/common"
 	"github.com/criteo-forks/espoke/probe"
 	"github.com/hashicorp/consul/api"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 // Watcher manages the pool of S3 endpoints to monitor


### PR DESCRIPTION
Add OpenSearch restore monitoring

This adds support for snapshot restore monitoring for OpenSearch, part
of which is incompatible with existing ElasticSearch code.

Added new option: --opensearch.

Add logging for when durability index is successfully restored, usually
every 24hrs, to help with troubleshooting.

Imports automatically sorted on modified files

----- 

Populate existing clusterConfig.Endpoint field and refactor NewEsProbe to use it

Allows direct usage of API without having to use the ES API go package,
if needed.